### PR TITLE
Fix tsc command under OS X

### DIFF
--- a/gulp/tasks/build-ts.js
+++ b/gulp/tasks/build-ts.js
@@ -15,7 +15,7 @@ function buildScript(project, watch, callback) {
     * p-parameter points to the project folder with the tsconfig.json.
     * outFile points to the output file for the compiled bundle.
     */
-    var cmd = 'node_modules\\.bin\\tsc -p ' + project + ' --outFile ' + outFile;
+    var cmd = 'node_modules/.bin/tsc -p ' + project + ' --outFile ' + outFile;
 
     if (watch)
        cmd = cmd + ' -w';

--- a/gulp/tasks/build-ts.js
+++ b/gulp/tasks/build-ts.js
@@ -9,17 +9,17 @@ var exec = require('child_process').exec;
 function buildScript(project, watch, callback) {
 
     var outFile = config.dev.root + config.scripts.dest + 'main.js';
-    
-    /* 
+
+    /*
     * Here's our typescript compiler command.
     * p-parameter points to the project folder with the tsconfig.json.
     * outFile points to the output file for the compiled bundle.
     */
     var cmd = 'node_modules\\.bin\\tsc -p ' + project + ' --outFile ' + outFile;
-    
+
     if (watch)
        cmd = cmd + ' -w';
-    
+
     var child = exec(cmd);
     child.stdout.pipe(process.stdout);
     child.stdout.on('data', function(chunk) {


### PR DESCRIPTION
Unix does not like `node_modules\\.bin\\tsc`: `"/bin/sh: node_modules.bintsc: command not found"`
It should be `node_modules/.bin/tsc` instead. Windows should recognize / just fine, example with Windows 7:

![screen shot 2016-04-30 at 15 33 30](https://cloud.githubusercontent.com/assets/643434/14936248/f6626c0a-0ee9-11e6-9d1f-f420bf9360d9.png)
